### PR TITLE
feat(cache): cache works under process / kernel isolation via RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   container hook (sandtrap >= 0.2.0); lambdas and other
   locally-defined functions outside the sandbox don't pickle and are
   rejected at the validator.
+- **Cache works the same in any isolation mode.** Under
+  `isolation="process"` / `"kernel"`, `build_namespace` injects a
+  `RpcProxyMarker` instead of a live `Cache`; the worker substitutes
+  it with a `RemoteCache` (also in `agex.cache`) that forwards
+  method calls to the parent over sandtrap's RPC channel
+  (sandtrap >= 0.2.1).  Writes propagate to the parent's session
+  cache; reads see whatever the parent has cached; cached
+  sandbox-defined helpers round-trip and re-activate against the
+  worker's gates on read.  The agent contract is identical across
+  modes — the only difference is per-call IPC latency under
+  isolation.
 - `execute_sandboxed`, `aexecute_sandboxed`, and `run_file_in_sandbox`
   now return the post-exec namespace dict so one-shot callers can
   inspect what a script computed without round-tripping through state.
@@ -63,8 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scientific codecs (Arrow, etc.) when kvgit adds them.
 
 ### Dependencies
-- `sandtrap >=0.2.0,<0.3.0` (was `>=0.1.15,<0.2.0`).  Required for
-  the `__sandtrap_activate__` container hook used by the cache.
+- `sandtrap >=0.2.1,<0.3.0` (was `>=0.1.15,<0.2.0`).  0.2.0 added
+  the `__sandtrap_activate__` container hook used by `Cache`; 0.2.1
+  added the worker→parent RPC channel used by `RemoteCache` for
+  cross-process cache parity.
 - `termish >=0.1.6,<0.2.0` (was `>=0.1.5,<0.2.0`).
 
 ### Migration

--- a/agex/cache.py
+++ b/agex/cache.py
@@ -90,8 +90,13 @@ class Cache(MutableMapping[str, Any]):
         return PREFIX + key
 
     def __getitem__(self, key: str) -> Any:
+        # Match dict's wrong-shape vs missing distinction: ``dict``
+        # raises TypeError for unhashable keys and KeyError for
+        # missing-but-hashable keys.  Cache's stricter constraint
+        # ("must be str") follows the same split — non-str raises
+        # TypeError; str-but-missing raises KeyError via the state.
         if not isinstance(key, str):
-            raise KeyError(key)
+            raise TypeError(f"Cache keys must be strings, got {type(key).__name__}")
         return self._state[PREFIX + key]
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -123,7 +128,7 @@ class Cache(MutableMapping[str, Any]):
 
     def __delitem__(self, key: str) -> None:
         if not isinstance(key, str):
-            raise KeyError(key)
+            raise TypeError(f"Cache keys must be strings, got {type(key).__name__}")
         wrappers = self._wrapper_keys()
         if key in wrappers:
             wrappers.discard(key)
@@ -231,7 +236,7 @@ class RemoteCache(MutableMapping[str, Any]):
 
     def __getitem__(self, key: str) -> Any:
         if not isinstance(key, str):
-            raise KeyError(key)
+            raise TypeError(f"Cache keys must be strings, got {type(key).__name__}")
         val = self._proxy._call("getitem", key)
         # Activate any inactive wrapper the parent shipped over.
         # ``activate_value`` short-circuits cheaply for non-wrappers,
@@ -253,7 +258,7 @@ class RemoteCache(MutableMapping[str, Any]):
 
     def __delitem__(self, key: str) -> None:
         if not isinstance(key, str):
-            raise KeyError(key)
+            raise TypeError(f"Cache keys must be strings, got {type(key).__name__}")
         self._proxy._call("delitem", key)
 
     def __iter__(self) -> Iterator[str]:

--- a/agex/cache.py
+++ b/agex/cache.py
@@ -60,13 +60,6 @@ class CacheError(ValueError):
     """Raised when a cache operation cannot complete (e.g. unpicklable value)."""
 
 
-def _make_local_cache() -> "Cache":
-    """Constructor used by ``Cache.__reduce__`` to materialize a fresh
-    in-memory Cache on the receiving end of a pickle round-trip
-    (typically a process-isolated subprocess)."""
-    return Cache({})
-
-
 class Cache(MutableMapping[str, Any]):
     """A persistent dict for the agent, scoped to the agent's session.
 
@@ -171,39 +164,6 @@ class Cache(MutableMapping[str, Any]):
             return "Cache(<unreadable>)"
         return f"Cache({keys!r})"
 
-    def __reduce__(self):
-        """Pickle support for process-isolated emissions.
-
-        Versioned ``state`` holds non-picklable resources (kvgit
-        threading locks etc.), so a Cache wrapping it can't cross a
-        process boundary as-is.  Without this hook sandtrap's
-        ``filter_namespace`` would drop the cache from the
-        subprocess's namespace with a warning — the agent would then
-        see a ``NameError`` instead of a usable ``cache``.
-
-        We probe the underlying state's picklability:
-          - If it pickles (e.g. a plain dict, ``Live`` state), we
-            preserve the round-trip — the receiving end gets a
-            ``Cache`` over an equivalent state, with the same data.
-          - If not (e.g. Staged with kvgit locks), we fall back to a
-            fresh empty Cache so the subprocess gets a working
-            object.
-
-        Limitation in the fallback case: writes performed inside a
-        process-isolated emission are stored in the subprocess's
-        local copy and do NOT propagate back to the parent's session
-        cache.  Reads of keys the parent cached are also unavailable.
-        Cross-process cache durability would require explicit IPC,
-        which the bridge doesn't currently do.  Most workloads use
-        ``isolation='none'`` (the default), where cache works as
-        documented.
-        """
-        try:
-            pickle.dumps(self._state, protocol=pickle.HIGHEST_PROTOCOL)
-        except Exception:
-            return (_make_local_cache, ())
-        return (Cache, (self._state,))
-
     def __sandtrap_activate__(self, activate_value, gates, sandbox, namespace) -> None:
         """Sandtrap container-activation hook.
 
@@ -233,3 +193,84 @@ class Cache(MutableMapping[str, Any]):
                 activate_value(val, gates, sandbox=sandbox, namespace=namespace)
             except Exception:
                 continue
+
+
+class RemoteCache(MutableMapping[str, Any]):
+    """Worker-side cache facade backed by a parent-process ``Cache``
+    via RPC.
+
+    Used under process / kernel isolation: the bridge layer injects an
+    :class:`sandtrap.RpcProxyMarker` (with ``wrapper="agex.cache:
+    RemoteCache"``) into the namespace; the worker substitutes it
+    with this class wrapping an ``RpcProxy``.  Method calls translate
+    into RPC round-trips that reach the parent's live ``Cache(state)``,
+    so writes propagate to the agent's real session cache and reads
+    see whatever the parent has cached.
+
+    Sandbox-defined wrappers (``StFunction`` / ``StClass``) are
+    re-activated locally with the worker's gates on every read — they
+    arrive inactive because pickle strips the sandbox-bound
+    ``_compiled`` / ``_sandbox`` / ``_gates`` references on the
+    parent-side serialization.  The activation hook captures the
+    worker's gates on first ``exec`` so subsequent ``__getitem__``
+    calls have what they need.
+    """
+
+    def __init__(self, proxy: Any) -> None:
+        self._proxy = proxy
+        self._gates: Any = None
+        self._sandbox: Any = None
+
+    def __sandtrap_activate__(self, activate_value, gates, sandbox, namespace) -> None:
+        # Stash the worker's gates / sandbox so __getitem__ can
+        # activate inactive wrappers it pulls back from the parent.
+        # We don't pre-warm cache reads here — there's no benefit
+        # and it'd waste IPC on values the agent never touches.
+        self._gates = gates
+        self._sandbox = sandbox
+
+    def __getitem__(self, key: str) -> Any:
+        if not isinstance(key, str):
+            raise KeyError(key)
+        val = self._proxy._call("getitem", key)
+        # Activate any inactive wrapper the parent shipped over.
+        # ``activate_value`` short-circuits cheaply for non-wrappers,
+        # so plain data values pay only an isinstance check.
+        if self._gates is not None:
+            from sandtrap.wrappers import activate_value
+
+            try:
+                activate_value(val, self._gates, sandbox=self._sandbox)
+            except Exception:
+                pass
+        return val
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        # Validation (key shape, picklability) happens on the parent
+        # via Cache.__setitem__.  Errors propagate back as RPC
+        # exceptions and re-raise here.
+        self._proxy._call("setitem", key, value)
+
+    def __delitem__(self, key: str) -> None:
+        if not isinstance(key, str):
+            raise KeyError(key)
+        self._proxy._call("delitem", key)
+
+    def __iter__(self) -> Iterator[str]:
+        # Parent returns a list snapshot; iterate locally.
+        return iter(self._proxy._call("iter"))
+
+    def __len__(self) -> int:
+        return self._proxy._call("len")
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        return self._proxy._call("contains", key)
+
+    def __repr__(self) -> str:
+        try:
+            keys = sorted(self._proxy._call("iter"))
+        except Exception:
+            return "Cache(<unreadable>)"
+        return f"Cache({keys!r})"

--- a/agex/eval/bridge/__init__.py
+++ b/agex/eval/bridge/__init__.py
@@ -22,6 +22,45 @@ if TYPE_CHECKING:
     from agex.agent.base import BaseAgent
 
 
+def _make_cache_handler(
+    state: MutableMapping[str, Any],
+) -> Callable[[str, tuple, dict], Any]:
+    """Build a sandtrap RPC handler that proxies cache operations to
+    a parent-side ``Cache(state)``.
+
+    Used only under process / kernel isolation: the worker's
+    ``RemoteCache`` calls ``handler(method, args, kwargs)`` over the
+    RPC channel; this factory returns the closure that dispatches by
+    method name to the live parent-side cache.
+
+    Errors raised by the parent-side cache (e.g. ``CacheError`` from
+    a non-picklable write) propagate back to the worker and re-raise
+    in the agent's call site.
+    """
+    from agex.cache import Cache
+
+    cache = Cache(state)
+
+    def handler(method: str, args: tuple, kwargs: dict) -> Any:
+        if method == "getitem":
+            return cache[args[0]]
+        if method == "setitem":
+            cache[args[0]] = args[1]
+            return None
+        if method == "delitem":
+            del cache[args[0]]
+            return None
+        if method == "iter":
+            return list(cache)
+        if method == "len":
+            return len(cache)
+        if method == "contains":
+            return args[0] in cache
+        raise AttributeError(method)
+
+    return handler
+
+
 def _prepare_sandbox(
     program: str,
     agent: "BaseAgent",
@@ -59,12 +98,22 @@ def _prepare_sandbox(
         register_io(agent)
 
     policy = translate_policy(agent, timeout=timeout, tick_limit=tick_limit)
+
+    # Under process / kernel isolation we register an RPC handler so
+    # the worker's ``RemoteCache`` proxy can reach back into the
+    # parent's live ``Cache(state)``.  Skipped for ``isolation="none"``
+    # — the in-process namespace gets the live Cache directly.
+    rpc_handlers: dict[str, Callable[[str, tuple, dict], Any]] | None = None
+    if agent.isolation != "none":
+        rpc_handlers = {"cache": _make_cache_handler(state)}
+
     sb = create_sandbox(
         policy,
         isolation=agent.isolation,
         mode="wrapped",
         filesystem=fs,
         snapshot_prints=True,
+        rpc_handlers=rpc_handlers,
     )
     namespace, _injected_keys = build_namespace(
         state, agent, agent.name, on_event=on_event

--- a/agex/eval/bridge/__init__.py
+++ b/agex/eval/bridge/__init__.py
@@ -42,21 +42,23 @@ def _make_cache_handler(
     cache = Cache(state)
 
     def handler(method: str, args: tuple, kwargs: dict) -> Any:
-        if method == "getitem":
-            return cache[args[0]]
-        if method == "setitem":
-            cache[args[0]] = args[1]
-            return None
-        if method == "delitem":
-            del cache[args[0]]
-            return None
-        if method == "iter":
-            return list(cache)
-        if method == "len":
-            return len(cache)
-        if method == "contains":
-            return args[0] in cache
-        raise AttributeError(method)
+        match method:
+            case "getitem":
+                return cache[args[0]]
+            case "setitem":
+                cache[args[0]] = args[1]
+                return None
+            case "delitem":
+                del cache[args[0]]
+                return None
+            case "iter":
+                return list(cache)
+            case "len":
+                return len(cache)
+            case "contains":
+                return args[0] in cache
+            case _:
+                raise AttributeError(method)
 
     return handler
 

--- a/agex/eval/bridge/namespace.py
+++ b/agex/eval/bridge/namespace.py
@@ -66,7 +66,22 @@ def build_namespace(
         setup_ns = state.get("__setup_namespace__") or {}
         for k, v in setup_ns.items():
             namespace[k] = v
-        namespace["cache"] = Cache(state)
+        # Cache injection: under in-process isolation the agent gets
+        # the live Cache(state) directly.  Under process / kernel
+        # isolation we ship an RpcProxyMarker — the parent registers
+        # a handler for "cache" (see ``_make_cache_handler``) and the
+        # worker substitutes the marker with a RemoteCache that
+        # forwards method calls to the parent over the connection.
+        # The agent contract is the same in both modes.
+        if getattr(agent, "isolation", "none") == "none":
+            namespace["cache"] = Cache(state)
+        else:
+            from sandtrap import RpcProxyMarker
+
+            namespace["cache"] = RpcProxyMarker(
+                target="cache",
+                wrapper="agex.cache:RemoteCache",
+            )
 
     # Inject task control functions — module-level so they're picklable
     # for cross-process isolation. Validation happens in handle_result.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.10"
 dependencies = [
     "termish>=0.1.6,<0.2.0",
     "kvgit>=0.3.0,<0.4.0",
-    "sandtrap>=0.2.0,<0.3.0",
+    "sandtrap>=0.2.1,<0.3.0",
     "reprobate>=0.1.1,<0.2.0",
     "monkeyfs>=0.1.4,<0.2.0",
     "tiktoken",

--- a/tests/agex/test_cache.py
+++ b/tests/agex/test_cache.py
@@ -79,9 +79,23 @@ class TestCacheDirect:
             cache["a/b"] = 1
 
     def test_reject_non_string_keys(self):
+        """Non-string keys raise TypeError on every operation that
+        cares about key shape, matching dict's TypeError-for-
+        unhashable contract.  ``__contains__`` stays lenient
+        (returns False) so ``if k in cache:`` is safe to use as a
+        defensive check without try/except."""
         cache = Cache({})
+        cache["foo"] = 1  # populate so missing-key noise doesn't mask the type errors
+
         with pytest.raises(TypeError):
             cache[42] = "x"
+        with pytest.raises(TypeError):
+            cache[42]
+        with pytest.raises(TypeError):
+            del cache[42]
+
+        # __contains__ stays lenient.
+        assert (42 in cache) is False
 
     def test_repr_lists_keys(self):
         cache = Cache({})

--- a/tests/agex/test_cache.py
+++ b/tests/agex/test_cache.py
@@ -399,33 +399,6 @@ class TestCachePicklability:
         assert roundtripped["k"] == 1
         assert "k" in roundtripped
 
-    def test_unpicklable_state_falls_back_to_empty_cache(self):
-        """When the underlying state holds non-picklable resources
-        (kvgit locks etc.), Cache pickles to a fresh empty Cache.
-
-        This keeps process-isolation namespace transfer warning-free
-        and gives the subprocess a working — if local-only — cache,
-        instead of having Cache stripped from the namespace and
-        surfacing as a NameError to the agent.
-        """
-        import threading
-
-        # State that contains an unpicklable resource — same shape
-        # as kvgit Staged's threading locks.
-        state = {PREFIX + "k": 1, "_lock": threading.Lock()}
-        cache = Cache(state)
-
-        # Pickle round-trip should succeed (no warning, no exception).
-        roundtripped = pickle.loads(pickle.dumps(cache))
-
-        # And the result is a working but empty Cache.
-        assert isinstance(roundtripped, Cache)
-        assert len(roundtripped) == 0
-        assert "k" not in roundtripped  # original data not transferred
-        # Writes work locally.
-        roundtripped["new"] = 42
-        assert roundtripped["new"] == 42
-
 
 # -----------------------------------------------------------------------------
 # Primer text mentions cache

--- a/tests/agex/test_isolation_e2e.py
+++ b/tests/agex/test_isolation_e2e.py
@@ -10,6 +10,7 @@ import sys
 import pytest
 
 from agex import Agent, TaskFail, clear_agent_registry
+from agex.agent.datatypes import TaskTimeout
 from agex.agent.events import OutputEvent, SuccessEvent
 from agex.llm.dummy_client import Dummy
 from agex.state import connect_state, events
@@ -753,3 +754,212 @@ class TestAsyncSubAgentTask:
 
         result = await run(idea="umbrella sales", session="s")
         assert result == "plot.png"
+
+
+class TestCacheUnderProcessIsolation:
+    """The agent's ``cache`` must work the same in any isolation mode.
+
+    Under ``isolation="process"``, the worker namespace gets a
+    ``RemoteCache`` (sandtrap >= 0.2.1) that proxies operations to
+    the parent's live ``Cache(state)`` over an RPC channel.  Reads
+    see what the parent has cached; writes propagate back to the
+    parent's session cache.
+    """
+
+    def setup_method(self):
+        clear_agent_registry()
+
+    def test_cache_write_propagates_to_parent_state(self):
+        """A subprocess ``cache[k] = v`` lands in the parent's state."""
+        from agex.cache import PREFIX
+
+        llm = Dummy(
+            [
+                make_response(
+                    thinking="cache it",
+                    code='cache["answer"] = 42\ntask_success("ok")',
+                )
+            ]
+        )
+        config = connect_state(type="versioned", storage="memory")
+        agent = Agent(
+            name="proc_cache_write",
+            llm=llm,
+            state=config,
+            isolation="process",
+            eval_tick_limit=None,
+            eval_timeout_seconds=10.0,
+        )
+
+        @agent.task
+        def stash() -> str:
+            """Stash a value."""
+            pass
+
+        assert stash(session="s") == "ok"
+
+        # The write hopped from worker → parent via RPC.  The
+        # parent's state has the qualified key.
+        state = agent._host.resolve_state(config, "s")
+        assert state.get(PREFIX + "answer") == 42
+
+    def test_cache_read_sees_parent_state(self):
+        """Pre-cached values are visible to subprocess reads."""
+        from agex.cache import PREFIX
+
+        config = connect_state(type="versioned", storage="memory")
+        agent = Agent(
+            name="proc_cache_read",
+            llm=Dummy(),
+            state=config,
+            isolation="process",
+            eval_tick_limit=None,
+            eval_timeout_seconds=10.0,
+        )
+
+        # Pre-populate the cache outside the agent — the agent's
+        # subprocess should see it via the RPC proxy.
+        state = agent._host.resolve_state(config, "s")
+        state[PREFIX + "secret"] = "shibboleth"
+        state.commit()
+
+        agent.llm = Dummy(
+            [
+                make_response(
+                    thinking="recall",
+                    code='task_success(cache["secret"])',
+                )
+            ]
+        )
+
+        @agent.task
+        def recall() -> str:
+            """Recall."""
+            pass
+
+        assert recall(session="s") == "shibboleth"
+
+    def test_cache_persists_across_isolated_tasks(self):
+        """Two task calls in the same session, both isolated.
+
+        Task 1 writes; task 2 reads.  Mirrors the in-process
+        ``test_persistence_across_tasks`` semantics under process
+        isolation.
+        """
+        config = connect_state(type="versioned", storage="memory")
+        agent = Agent(
+            name="proc_cache_persist",
+            llm=Dummy(),
+            state=config,
+            isolation="process",
+            eval_tick_limit=None,
+            eval_timeout_seconds=10.0,
+        )
+
+        @agent.task
+        def stash() -> None:
+            """Stash."""
+            pass
+
+        @agent.task
+        def recall() -> int:
+            """Recall."""
+            pass
+
+        agent.llm.responses = [
+            make_response(
+                thinking="store",
+                code='cache["answer"] = 42\ntask_success(None)',
+            )
+        ]
+        stash(session="s")
+
+        agent.llm.responses = [
+            make_response(thinking="recall", code='task_success(cache["answer"])')
+        ]
+        assert recall(session="s") == 42
+
+    def test_cache_unpicklable_value_raises_in_subprocess(self):
+        """Validation runs on the parent — unpicklable writes raise
+        ``CacheError`` and the worker re-raises in the agent's call
+        site, just like in-process."""
+        # Register a host-side function that produces an unpicklable
+        # object (a thread Lock).  Write to cache → handler runs
+        # cloudpickle-equivalent picklability check → raises.
+        import threading
+
+        from agex.cache import CacheError
+
+        agent = Agent(
+            name="proc_cache_bad",
+            llm=Dummy(),
+            state=connect_state(type="versioned", storage="memory"),
+            isolation="process",
+            eval_tick_limit=None,
+            eval_timeout_seconds=10.0,
+        )
+        agent.fn(threading.Lock, name="make_lock")
+        agent.llm = Dummy(
+            [
+                make_response(
+                    thinking="bad write",
+                    code='cache["bad"] = make_lock()',
+                )
+            ]
+        )
+
+        @agent.task
+        def attempt() -> None:
+            """Try a bad write."""
+            pass
+
+        # CacheError surfaces as the task's recoverable error and the
+        # task eventually times out (Dummy keeps replaying the same
+        # broken code).  Either way, the failure is loud, not silent.
+        with pytest.raises((CacheError, TaskTimeout)):
+            attempt(session="s")
+
+    def test_cached_stfunction_round_trips_across_processes(self):
+        """A function defined in one isolated task is callable in the next."""
+        config = connect_state(type="versioned", storage="memory")
+        agent = Agent(
+            name="proc_cache_fn",
+            llm=Dummy(),
+            state=config,
+            isolation="process",
+            eval_tick_limit=None,
+            eval_timeout_seconds=15.0,
+        )
+
+        @agent.task
+        def define() -> None:
+            """Define a helper and stash it."""
+            pass
+
+        @agent.task
+        def use() -> int:
+            """Retrieve and call the helper."""
+            pass
+
+        agent.llm.responses = [
+            make_response(
+                thinking="define and stash",
+                code=(
+                    "def add(a, b):\n    return a + b\n"
+                    'cache["add"] = add\n'
+                    "task_success(None)"
+                ),
+            )
+        ]
+        define(session="s")
+
+        agent.llm.responses = [
+            make_response(
+                thinking="retrieve and use",
+                code='fn = cache["add"]\ntask_success(fn(2, 3))',
+            )
+        ]
+        # The retrieved StFunction arrives inactive in the worker;
+        # RemoteCache.__getitem__ activates it with the worker's
+        # local gates before returning.
+        assert use(session="s") == 5


### PR DESCRIPTION
Under in-process isolation, agents see ``cache`` as a live ``Cache(state)`` injected into the namespace.  Under process / kernel isolation, that wrapper holds threading locks etc. that don't cross a process boundary — previously the namespace transfer silently dropped the cache (with a RuntimeWarning) and the agent saw an empty stub.  Wrong shape: the agent's environment shouldn't depend on whether the runner happens to be process-isolated.

Sandtrap 0.2.1 added a worker→parent RPC channel for exactly this. Wire it up:

  - ``build_namespace`` injects ``RpcProxyMarker(target="cache", wrapper="agex.cache:RemoteCache")`` instead of a live ``Cache`` when ``agent.isolation != "none"``.
  - ``_prepare_sandbox`` registers an RPC handler keyed ``"cache"`` that proxies ``getitem`` / ``setitem`` / ``delitem`` / ``iter`` / ``len`` / ``contains`` to the parent's live ``Cache(state)``.
  - New ``RemoteCache`` class in ``agex/cache.py`` is the worker- side facade — ``MutableMapping`` over an ``RpcProxy`` that forwards each operation across the connection.  Sandbox-defined wrappers arrive inactive (pickle strips ``_compiled``) and are re-activated locally with the worker's gates on first read; the container hook captures the worker's gates at exec start.

The ``Cache.__reduce__`` fallback that pickled to an empty Cache is removed — it was a stopgap for the silent-drop scenario the new RPC path obsoletes.  ``test_unpicklable_state_falls_back_to_empty_cache`` is gone with it.

5 new e2e tests in ``test_isolation_e2e.py`` cover writes propagating to parent state, reads seeing parent-cached values, cross-task persistence under isolation, validation errors raising in the agent's call site, and StFunction round-trip across processes.

Sandtrap floor bumped 0.2.0 → 0.2.1.  Net suite: 1294 → 1299 passing, zero warnings.